### PR TITLE
fixed halftensor input type mismatch by adding in autocasting

### DIFF
--- a/bonito/ctc/model.py
+++ b/bonito/ctc/model.py
@@ -33,8 +33,9 @@ class Model(Module):
         self.decoder = Decoder(self.features, len(self.alphabet))
 
     def forward(self, x):
-        encoded = self.encoder(x)
-        return self.decoder(encoded)
+        with torch.cuda.amp.autocast():
+            encoded = self.encoder(x)
+            return self.decoder(encoded)
 
     def decode(self, x, beamsize=5, threshold=1e-3, qscores=False, return_path=False):
         x = x.exp().cpu().numpy().astype(np.float32)

--- a/bonito/ctc/modeltinynoskipx01.py
+++ b/bonito/ctc/modeltinynoskipx01.py
@@ -29,8 +29,9 @@ class ModelTinyNoSkipX01(Module):
         self.decoder = Decoder(48, len(self.alphabet))
 
     def forward(self, x):
-        encoded = self.encoder(x)
-        return self.decoder(encoded)
+        with torch.cuda.amp.autocast():
+            encoded = self.encoder(x)
+            return self.decoder(encoded)
 
     def decode(self, x, beamsize=5, threshold=1e-3, qscores=False, return_path=False):
         x = x.exp().cpu().numpy().astype(np.float32)

--- a/bonito/ctc/modeltinynoskipx011.py
+++ b/bonito/ctc/modeltinynoskipx011.py
@@ -30,8 +30,9 @@ class ModelTinyNoSkipX011(Module):
         self.decoder = Decoder(48, len(self.alphabet))
 
     def forward(self, x):
-        encoded = self.encoder(x)
-        return self.decoder(encoded)
+        with torch.cuda.amp.autocast():
+            encoded = self.encoder(x)
+            return self.decoder(encoded)
 
     def decode(self, x, beamsize=5, threshold=1e-3, qscores=False, return_path=False):
         x = x.exp().cpu().numpy().astype(np.float32)

--- a/bonito/ctc/modeltinynoskipx0111.py
+++ b/bonito/ctc/modeltinynoskipx0111.py
@@ -29,8 +29,9 @@ class ModelTinyNoSkipX0111(Module):
         self.decoder = Decoder(48, len(self.alphabet))
 
     def forward(self, x):
-        encoded = self.encoder(x)
-        return self.decoder(encoded)
+        with torch.cuda.amp.autocast():
+            encoded = self.encoder(x)
+            return self.decoder(encoded)
 
     def decode(self, x, beamsize=5, threshold=1e-3, qscores=False, return_path=False):
         x = x.exp().cpu().numpy().astype(np.float32)

--- a/bonito/ctc/modeltinynoskipx1.py
+++ b/bonito/ctc/modeltinynoskipx1.py
@@ -28,8 +28,9 @@ class ModelTinyNoSkipX1(Module):
         self.decoder = Decoder(48, len(self.alphabet))
 
     def forward(self, x):
-        encoded = self.encoder(x)
-        return self.decoder(encoded)
+        with torch.cuda.amp.autocast():
+            encoded = self.encoder(x)
+            return self.decoder(encoded)
 
     def decode(self, x, beamsize=5, threshold=1e-3, qscores=False, return_path=False):
         x = x.exp().cpu().numpy().astype(np.float32)

--- a/bonito/ctc/modeltinynoskipx2.py
+++ b/bonito/ctc/modeltinynoskipx2.py
@@ -29,8 +29,9 @@ class ModelTinyNoSkipX2(Module):
         self.decoder = Decoder(24, len(self.alphabet))
 
     def forward(self, x):
-        encoded = self.encoder(x)
-        return self.decoder(encoded)
+        with torch.cuda.amp.autocast():
+            encoded = self.encoder(x)
+            return self.decoder(encoded)
 
     def decode(self, x, beamsize=5, threshold=1e-3, qscores=False, return_path=False):
         x = x.exp().cpu().numpy().astype(np.float32)

--- a/bonito/ctc/modeltinynoskipx3.py
+++ b/bonito/ctc/modeltinynoskipx3.py
@@ -28,8 +28,9 @@ class ModelTinyNoSkipX3(Module):
         self.decoder = Decoder(12, len(self.alphabet))
 
     def forward(self, x):
-        encoded = self.encoder(x)
-        return self.decoder(encoded)
+        with torch.cuda.amp.autocast():
+            encoded = self.encoder(x)
+            return self.decoder(encoded)
 
     def decode(self, x, beamsize=5, threshold=1e-3, qscores=False, return_path=False):
         x = x.exp().cpu().numpy().astype(np.float32)

--- a/bonito/ctc/modeltinynoskipx4.py
+++ b/bonito/ctc/modeltinynoskipx4.py
@@ -29,8 +29,9 @@ class ModelTinyNoSkipX4(Module):
         self.decoder = Decoder(6, len(self.alphabet))
 
     def forward(self, x):
-        encoded = self.encoder(x)
-        return self.decoder(encoded)
+        with torch.cuda.amp.autocast():
+            encoded = self.encoder(x)
+            return self.decoder(encoded)
 
     def decode(self, x, beamsize=5, threshold=1e-3, qscores=False, return_path=False):
         x = x.exp().cpu().numpy().astype(np.float32)


### PR DESCRIPTION
This seems to fix the errors I was receiving when trying to run TargetCall (see issue #1).